### PR TITLE
Remove install instructions from eOS, in favour of eOS-Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installing eOS
 
-See https://ChatTheatre.github.io/eOS-Doc/installing.html
+See [the install instructions](https://ChatTheatre.github.io/eOS-Doc/installing.md)
 
 * TBD: Do we
    * copy files to repository eos root like phantasmal does?

--- a/README.md
+++ b/README.md
@@ -2,51 +2,9 @@
 
 **After the deepest darkness before the dawn (SkotOS) comes the first glimmerings of the rosy-fingered dawn (eOS)**
 
-## Installation
+## Installing eOS
 
-```
-# Install eOS repository with recursive submodules
-
-git clone git@github.com:ChatTheatre/eOS.git --recursive
-
-# Move to eOS root folder
-
-cd eOS
-
-## Make sure all submodules are checked out to master branch
-
-git submodule foreach --recursive git checkout master
-
-## Move to the DGD source director
-
-cd dgd/src
-
-# make and install the current dgd which will be at …/eos/dgd/bin/dgd
-
-make install
-
-# return to repository root
-
-cd ../..
-
-# test dgd compiled, should get usage help message
-
-./dgd/bin/dgd
-
-# Add eos path to eos/eos.DGD
-
-pwd
-nano ./eos.dgd
-
-# start dgd
-
-./dgd/bin/dgd ./eos.dgd
-
-# login telnet port
-
-telnet local.host 50100
-
-```
+See https://ChatTheatre.github.io/eOS-Doc/installing.html
 
 * TBD: Do we
    * copy files to repository eos root like phantasmal does?


### PR DESCRIPTION
There's a corresponding PR in eOS-Doc to add them there.